### PR TITLE
Add games api handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 Novel Go games written in Go
 
 + Motivation
-Normal Go games with small board sizes have been thoroughly studied, and mature software for full board size is also available.
-It'd be intersting to see what it's like if we invent some "novel" Go games by tweaking some of its rules,
-for example, by making the board cyclic, so it "wraps" around in all directions.
-This eliminates the idea of "edges" and "corners" and the board is now a "cyclic group" of equivalence.
+Normal Go games with small board sizes have been thoroughly studied,
+and mature softwares for the full 19x19 board size are also available.
+It's intersting to see what it'd be like if we invent some "novel" Go games by tweaking some of its rules.
+For example, by making the board cyclic, so it "wraps" around in all directions.
+This eliminates the notion of "edges" and "corners", and the board is now a "cyclic group" of equivalence.
 This repo is created to play with such "novel" setups.
-At the moment it only has a CLI tool for "cyclic" games, and a basic backend server for CRUD operations.
-A front end will be created in the future.
+
++ Status
+At the moment it only has a CLI tool for "cyclic" games (full logic with toggle not implemented yet),
+which is able to save and read gamplay files.
+after adding a basic backend server for CRUD operations, a suitable frontend will also be created in the future.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # novelgo
-Novel Go game written in Go
+Novel Go games written in Go
+
++ Motivation
+Normal Go games with small board sizes have been thoroughly studied, and mature software for full board size is also available.
+It'd be intersting to see what it's like if we invent some "novel" Go games by tweaking some of its rules,
+for example, by making the board cyclic, so it "wraps" around in all directions.
+This eliminates the idea of "edges" and "corners" and the board is now a "cyclic group" of equivalence.
+This repo is created to play with such "novel" setups.
+At the moment it only has a CLI tool for "cyclic" games, and a basic backend server for CRUD operations.
+A front end will be created in the future.

--- a/server/novelgo/go.mod
+++ b/server/novelgo/go.mod
@@ -11,11 +11,13 @@ require (
 	github.com/go-openapi/swag v0.23.0
 	github.com/go-openapi/validate v0.24.0
 	github.com/jessevdk/go-flags v1.6.1
+	github.com/stretchr/testify v1.9.0
 	golang.org/x/net v0.30.0
 )
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
@@ -25,6 +27,7 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.mongodb.org/mongo-driver v1.14.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect

--- a/server/novelgo/internal/pkg/handlers/game_handlers.go
+++ b/server/novelgo/internal/pkg/handlers/game_handlers.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"errors"
+	"novelgo/internal/pkg/models"
+)
+
+var games = make(map[string]*models.Game)
+
+// ListGames returns all games
+func ListGames() []*models.Game {
+	var result []*models.Game
+	for _, game := range games {
+		result = append(result, game)
+	}
+	return result
+}
+
+// CreateGame adds a new game
+func CreateGame(game *models.Game) (*models.Game, error) {
+	games[*game.ID] = game
+	return game, nil
+}
+
+// GetGameByID returns a game by ID
+func GetGameByID(id string) (*models.Game, error) {
+	game, exists := games[id]
+	if !exists {
+		return nil, errors.New("game not found")
+	}
+	return game, nil
+}
+
+// UpdateGame updates an existing game
+func UpdateGame(id string, game *models.Game) error {
+	_, exists := games[id]
+	if !exists {
+		return errors.New("game not found")
+	}
+	games[id] = game
+	return nil
+}
+
+// DeleteGame removes a game by ID
+func DeleteGame(id string) error {
+	_, exists := games[id]
+	if !exists {
+		return errors.New("game not found")
+	}
+	delete(games, id)
+	return nil
+}

--- a/server/novelgo/internal/pkg/handlers/game_handlers.go
+++ b/server/novelgo/internal/pkg/handlers/game_handlers.go
@@ -3,8 +3,12 @@ package handlers
 import (
 	"errors"
 	"novelgo/internal/pkg/models"
+
+	"github.com/google/uuid"
 )
 
+// Use a map to simulate a DB
+// TODO: Replace with an actual DB
 var games = make(map[string]*models.Game)
 
 // ListGames returns all games
@@ -18,6 +22,8 @@ func ListGames() []*models.Game {
 
 // CreateGame adds a new game
 func CreateGame(game *models.Game) (*models.Game, error) {
+	ID := uuid.New().String()
+	game.ID = &ID
 	games[*game.ID] = game
 	return game, nil
 }

--- a/server/novelgo/internal/pkg/handlers/game_handlers.go
+++ b/server/novelgo/internal/pkg/handlers/game_handlers.go
@@ -21,6 +21,8 @@ func ListGames() []*models.Game {
 }
 
 // CreateGame adds a new game
+// The ID field from the request is ignored
+// A new uuid will be generated for the new game
 func CreateGame(game *models.Game) (*models.Game, error) {
 	ID := uuid.New().String()
 	game.ID = &ID

--- a/server/novelgo/internal/pkg/restapi/api_test.go
+++ b/server/novelgo/internal/pkg/restapi/api_test.go
@@ -174,6 +174,13 @@ func TestDeleteGame(t *testing.T) {
 }
 
 // Helper function to remove ID fields from JSON strings
+//
+// Parameters:
+// - j: Serialised string of the game to remove ID, in JSON format.
+//
+// Returns:
+// - string: Serialised string of the game, with remove ID removed.
+// - error: Error if any.
 func rmID(j string) (string, error) {
 	empty := ""
 	// Try unmarhsal into single object first
@@ -198,6 +205,15 @@ func rmID(j string) (string, error) {
 	return string(s), nil
 }
 
+// Helper function to create a test game on the server when testing other operations
+//
+// Parameters:
+// - gameJSON: Serialised string of the game to create, in JSON format.
+// - h: The http handler to create the new game on.
+//
+// Returns:
+// - string: The ID of the new game returned from server.
+// - error: Error if any.
 func createTestGame(gameJSON string, h *http.Handler) (string, error) {
 	req, err := http.NewRequest("POST", "/games", strings.NewReader(gameJSON))
 	if err != nil {

--- a/server/novelgo/internal/pkg/restapi/api_test.go
+++ b/server/novelgo/internal/pkg/restapi/api_test.go
@@ -1,8 +1,11 @@
 package restapi
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"novelgo/internal/pkg/models"
 	"novelgo/internal/pkg/restapi/operations"
 	"strings"
 	"testing"
@@ -29,18 +32,27 @@ func TestListGames(t *testing.T) {
 	assert.JSONEq(t, expected, rr.Body.String())
 
 	// Test non-empty
+	// Post 1 item to server
 	gameJSON := `{"Id":"1","Name":"Test game","Settings":{"BoardWidth":10,"BoardHeight":10},"Gameplay":{"PlayerMoves":[{"Row":1,"Col":1}]}}`
 	req, err = http.NewRequest("POST", "/games", strings.NewReader(gameJSON))
 	assert.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusOK, rr.Code)
+	// Call the endpoint again, expecting the posted item
 	req, err = http.NewRequest("GET", "/games", nil)
 	assert.NoError(t, err)
 	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.JSONEq(t, `[`+gameJSON+`]`, rr.Body.String())
+	// Remove the ID fields before comparison
+	gameJSON, _ = rmID(gameJSON)
+	resJSON, err := rmID(rr.Body.String())
+	fmt.Println(rr.Body.String())
+	assert.NoError(t, err)
+	// Wrap in array before comparison
+	gameJSON = `[` + gameJSON + `]`
+	assert.JSONEq(t, gameJSON, resJSON)
 }
 
 func TestCreateGame(t *testing.T) {
@@ -58,5 +70,34 @@ func TestCreateGame(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusCreated, rr.Code)
-	assert.JSONEq(t, gameJSON, rr.Body.String())
+	// Remove the ID fields before comparison
+	gameJSON, _ = rmID(gameJSON)
+	resJSON, err := rmID(rr.Body.String())
+	assert.NoError(t, err)
+	assert.JSONEq(t, gameJSON, resJSON)
+}
+
+// Helper function to remove ID fields from JSON strings
+func rmID(j string) (string, error) {
+	empty := ""
+	// Try unmarhsal into single object first
+	var game models.Game
+	err := json.Unmarshal([]byte(j), &game)
+	if err != nil {
+		// Check for case of array
+		var games []models.Game
+		err := json.Unmarshal([]byte(j), &games)
+		if err != nil {
+			return "", err
+		}
+		for i := range games {
+			games[i].ID = &empty
+		}
+		s, err := json.Marshal(games)
+		return string(s), nil
+	}
+	// Single object marshal succeded
+	game.ID = &empty
+	s, err := json.Marshal(game)
+	return string(s), nil
 }

--- a/server/novelgo/internal/pkg/restapi/api_test.go
+++ b/server/novelgo/internal/pkg/restapi/api_test.go
@@ -179,7 +179,7 @@ func TestDeleteGame(t *testing.T) {
 // - j: Serialised string of the game to remove ID, in JSON format.
 //
 // Returns:
-// - string: Serialised string of the game, with remove ID removed.
+// - string: Serialised string of the game, with ID field removed.
 // - error: Error if any.
 func rmID(j string) (string, error) {
 	empty := ""

--- a/server/novelgo/internal/pkg/restapi/api_test.go
+++ b/server/novelgo/internal/pkg/restapi/api_test.go
@@ -1,0 +1,62 @@
+package restapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"novelgo/internal/pkg/restapi/operations"
+	"strings"
+	"testing"
+
+	"github.com/go-openapi/loads"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListGames(t *testing.T) {
+	swaggerSpec, err := loads.Analyzed(SwaggerJSON, "")
+	assert.NoError(t, err)
+	api := operations.NewNovelgoAPI(swaggerSpec)
+	server := NewServer(api)
+	defer server.Shutdown()
+
+	// Test empty
+	handler := configureAPI(api)
+	req, err := http.NewRequest("GET", "/games", nil)
+	assert.NoError(t, err)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	expected := `[]`
+	assert.JSONEq(t, expected, rr.Body.String())
+
+	// Test non-empty
+	gameJSON := `{"Id":"1","Name":"Test game","Settings":{"BoardWidth":10,"BoardHeight":10},"Gameplay":{"PlayerMoves":[{"Row":1,"Col":1}]}}`
+	req, err = http.NewRequest("POST", "/games", strings.NewReader(gameJSON))
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	req, err = http.NewRequest("GET", "/games", nil)
+	assert.NoError(t, err)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.JSONEq(t, `[`+gameJSON+`]`, rr.Body.String())
+}
+
+func TestCreateGame(t *testing.T) {
+	swaggerSpec, err := loads.Analyzed(SwaggerJSON, "")
+	assert.NoError(t, err)
+	api := operations.NewNovelgoAPI(swaggerSpec)
+	server := NewServer(api)
+	defer server.Shutdown()
+
+	handler := configureAPI(api)
+	gameJSON := `{"Id":"1","Name":"Test game","Settings":{"BoardWidth":10,"BoardHeight":10},"Gameplay":{"PlayerMoves":[{"Row":1,"Col":1}]}}`
+	req, err := http.NewRequest("POST", "/games", strings.NewReader(gameJSON))
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusCreated, rr.Code)
+	assert.JSONEq(t, gameJSON, rr.Body.String())
+}

--- a/server/novelgo/internal/pkg/restapi/api_test.go
+++ b/server/novelgo/internal/pkg/restapi/api_test.go
@@ -114,10 +114,10 @@ func TestPutGame(t *testing.T) {
 	server := NewServer(api)
 	defer server.Shutdown()
 
-	handler := configureAPI(api)
-	gameJSON := `{"Id":"1","Name":"Test game","Settings":{"BoardWidth":10,"BoardHeight":10},"Gameplay":{"PlayerMoves":[{"Row":1,"Col":1}]}}`
 	// Update non-existent game
 	// Expect error
+	handler := configureAPI(api)
+	gameJSON := `{"Id":"1","Name":"Test game","Settings":{"BoardWidth":10,"BoardHeight":10},"Gameplay":{"PlayerMoves":[{"Row":1,"Col":1}]}}`
 	req, err := http.NewRequest("PUT", "/games/1", strings.NewReader(gameJSON))
 	assert.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")

--- a/server/novelgo/internal/pkg/restapi/configure_novelgo.go
+++ b/server/novelgo/internal/pkg/restapi/configure_novelgo.go
@@ -75,7 +75,7 @@ func configureAPI(api *operations.NovelgoAPI) http.Handler {
 	})
 	api.UpdateGameHandler = operations.UpdateGameHandlerFunc(func(params operations.UpdateGameParams) middleware.Responder {
 		updatedGame := &models.Game{
-			ID:       &params.GameID,
+			ID:       &params.GameID, // The ID field in the request body is ignored
 			Name:     params.Body.Name,
 			Settings: params.Body.Settings,
 			Gameplay: params.Body.Gameplay,

--- a/server/novelgo/internal/pkg/restapi/configure_novelgo.go
+++ b/server/novelgo/internal/pkg/restapi/configure_novelgo.go
@@ -78,6 +78,7 @@ func configureAPI(api *operations.NovelgoAPI) http.Handler {
 			ID:       &params.GameID,
 			Name:     params.Body.Name,
 			Settings: params.Body.Settings,
+			Gameplay: params.Body.Gameplay,
 		}
 		err := handlers.UpdateGame(params.GameID, updatedGame)
 		if err != nil {


### PR DESCRIPTION
To persist gameplay data on a server, and enable usage of a more user-friendly UI, a `games` API endpoint is desirable for interaction with the frontend.
This PR:
- Implemented basic CRUD logics for the new `games` endpoint.
- Expanded readme to include more background information.
The yaml spec for the API and auto-generated boilerplates are on this PR: https://github.com/fanzeng/novelgo/pull/4